### PR TITLE
🃏shuffle anndata

### DIFF
--- a/dvc.lock
+++ b/dvc.lock
@@ -17,18 +17,18 @@ test_train_val_split:
     md5: 9126c2e5dcd4cacac9657b0111ced8d8
     size: 1680490384
   - path: src/pipeline/test_train_val_split.py
-    md5: 5cc4ec03e3df8774e7bb0680e55262c4
-    size: 941
+    md5: 8067c9c08b26525ef81eb1e4950fad05
+    size: 922
   outs:
   - path: data/intermediate/covid_test_data.h5ad
-    md5: 4dfd09daac884696f029a0048dc3e0fa
-    size: 176913279
+    md5: 0dc9ec980ed260d85c4cbf6a199a4800
+    size: 175193054
   - path: data/intermediate/covid_train_data.h5ad
-    md5: b6d27edb99d5e7d72955bc6f4c4b951d
-    size: 1345308645
+    md5: 37004a4fe85b003316bed72f79c1207f
+    size: 1355067873
   - path: data/intermediate/covid_val_data.h5ad
-    md5: d0cdb8feb7a3655603cdb8c9b05598db
-    size: 174185618
+    md5: 323c361a180a4131b7a50c53e61f8cdb
+    size: 175066788
 train_vae:
   cmd: $VAE_PY src/pipeline/train_vae.py
   deps:

--- a/src/pipeline/test_train_val_split.py
+++ b/src/pipeline/test_train_val_split.py
@@ -1,6 +1,7 @@
 """create an 8:1:1 split for train, test and validation"""
 
 import anndata
+import random
 from tqdm import tqdm
 from loguru import logger
 from pipeline.helpers.paths import RAW_DATA_FP, DATA_SPLIT_FPS
@@ -10,9 +11,11 @@ logger.info("Please note this process takes about 10 minutes")
 covid_dataset = anndata.read_h5ad(RAW_DATA_FP, backed="r")
 
 n, _ = covid_dataset.shape
+idxs = random.sample(range(n), k=n)
 split_idx_1 = int(n * 0.8)
 split_idx_2 = int(n * 0.9)
 train_fp, test_fp, val_fp = DATA_SPLIT_FPS
+
 splits = [
     ("train", None, split_idx_1, train_fp),
     ("test", split_idx_1, split_idx_2, test_fp),
@@ -20,8 +23,6 @@ splits = [
 ]
 for split_type, i, j, outfp in tqdm(splits, unit="split"):
     logger.info("Extracting single cell {} data within [{},{})", split_type, i, j)
-    split = covid_dataset[slice(i,j), :]
+    split = covid_dataset[idxs[i:j]]
     split.write_h5ad(outfp, compression="gzip")
-    # bug workaround: after writing, we need to refresh the view
     covid_dataset = anndata.read_h5ad(RAW_DATA_FP, backed="r")
-


### PR DESCRIPTION
data were ordered, such that the validation data had only healthy examples

shuffle the data uniformly